### PR TITLE
chore: Update Terraform required_version for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please ensure that you have a clear plan and architecture for your Azure Applica
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.71)
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -16,7 +16,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -149,7 +149,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -7,7 +7,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/front_end_ip_private_custom_name/README.md
+++ b/examples/front_end_ip_private_custom_name/README.md
@@ -16,7 +16,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -219,7 +219,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/front_end_ip_private_custom_name/main.tf
+++ b/examples/front_end_ip_private_custom_name/main.tf
@@ -7,7 +7,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/kv_selfssl_waf_https_app_gateway/README.md
+++ b/examples/kv_selfssl_waf_https_app_gateway/README.md
@@ -12,7 +12,7 @@ For enhanced security, SSL certificates are managed using Azure Key Vault. This 
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -230,7 +230,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/kv_selfssl_waf_https_app_gateway/main.tf
+++ b/examples/kv_selfssl_waf_https_app_gateway/main.tf
@@ -6,7 +6,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/rewrite_rule/README.md
+++ b/examples/rewrite_rule/README.md
@@ -13,7 +13,7 @@ This scenario tests re-write rules.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -190,7 +190,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/rewrite_rule/main.tf
+++ b/examples/rewrite_rule/main.tf
@@ -7,7 +7,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/selfssl_waf_https_app_gateway/README.md
+++ b/examples/selfssl_waf_https_app_gateway/README.md
@@ -15,7 +15,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -219,7 +219,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/selfssl_waf_https_app_gateway/main.tf
+++ b/examples/selfssl_waf_https_app_gateway/main.tf
@@ -6,7 +6,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/simple_http_app_gateway_internal/README.md
+++ b/examples/simple_http_app_gateway_internal/README.md
@@ -9,7 +9,7 @@ This deploys the module in its simplest form.
 ```hcl
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -170,7 +170,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/simple_http_app_gateway_internal/main.tf
+++ b/examples/simple_http_app_gateway_internal/main.tf
@@ -1,6 +1,6 @@
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/simple_http_host_multiple_sites_app_gateway/README.md
+++ b/examples/simple_http_host_multiple_sites_app_gateway/README.md
@@ -14,7 +14,7 @@ This deploys the module in its simplest form.
 # The input from https://learn.microsoft.com/en-us/azure/application-gateway/tutorial-multiple-sites-cli
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -200,7 +200,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/simple_http_host_multiple_sites_app_gateway/main.tf
+++ b/examples/simple_http_host_multiple_sites_app_gateway/main.tf
@@ -4,7 +4,7 @@
 # The input from https://learn.microsoft.com/en-us/azure/application-gateway/tutorial-multiple-sites-cli
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/simple_http_host_single_site_app_gateway/README.md
+++ b/examples/simple_http_host_single_site_app_gateway/README.md
@@ -16,7 +16,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -149,7 +149,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/simple_http_host_single_site_app_gateway/main.tf
+++ b/examples/simple_http_host_single_site_app_gateway/main.tf
@@ -7,7 +7,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/simple_http_probe_app_gateway/README.md
+++ b/examples/simple_http_probe_app_gateway/README.md
@@ -16,7 +16,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -200,7 +200,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/simple_http_probe_app_gateway/main.tf
+++ b/examples/simple_http_probe_app_gateway/main.tf
@@ -6,7 +6,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/examples/simple_waf_http_app_gateway/README.md
+++ b/examples/simple_waf_http_app_gateway/README.md
@@ -17,7 +17,7 @@ This deploys the module in its simplest form.
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {
@@ -187,7 +187,7 @@ module "application_gateway" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.5)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.0, < 4.0)
 

--- a/examples/simple_waf_http_app_gateway/main.tf
+++ b/examples/simple_waf_http_app_gateway/main.tf
@@ -8,7 +8,7 @@
 
 #----------All Required Provider Section----------- 
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
 
   required_providers {
     azurerm = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description

This PR updates the Terraform `required_version` constraint to ensure consistency across all AVM modules. The constraint has been set to `>= 1.9, < 2.0` to maintain compatibility and leverage the features available in Terraform versions within this range.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
