### PR TITLE
fix: make ssl_certificates output sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -56,6 +56,7 @@ output "resource_id" {
 output "ssl_certificates" {
   description = "Information about SSL certificates used by the Application Gateway, including their names and other details."
   value       = azurerm_application_gateway.this.ssl_certificate
+  sensitive   = true
 }
 
 output "tags" {


### PR DESCRIPTION
Fixes sensitive output issue
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 56:
│   56: output "ssl_certificates" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
