### PR TITLE
fix: unset min_protocol_version when using predefined ssl policy

### DIFF
--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -17,6 +17,13 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Triage :mag:"
+          - addReply:
+              reply: |
+                > [!IMPORTANT]
+                > **The "Needs: Triage :mag:" label must be removed once the triage process is complete!**
+
+                > [!TIP]
+                > For additional guidance on how to triage this issue/PR, see the [Terraform Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/terraform-issue-triage) documentation.
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -47,7 +54,7 @@ configuration:
               label: "Status: Won't Fix :broken_heart:"
           - closeIssue
 
-      - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
+      - description: 'ITA11 - When the author replies, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
           - or:
               - payloadType: Pull_Request_Review_Comment
@@ -57,9 +64,13 @@ configuration:
                 action: Closed
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
+          - isActivitySender:
+              issueAuthor: true
         then:
           - removeLabel:
               label: "Needs: Author Feedback :ear:"
+          - removeLabel:
+              label: "Status: No Recent Activity :zzz:"
           - addLabel:
               label: "Needs: Attention :wave:"
 
@@ -89,12 +100,14 @@ configuration:
                   label: "Type: New Module Proposal :bulb:"
               - hasLabel:
                   label: "Type: Question/Feedback :raising_hand:"
+              - hasLabel:
+                  label: "Type: Security Bug :lock:"
           - isAssignedToSomeone
         then:
           - removeLabel:
               label: "Needs: Triage :mag:"
 
-      - description: 'ITA20 - If the type is feature request, add the "Type: Feature Request :heavy_plus_sign:" label on the issue'
+      - description: 'ITA20 - If the type is feature request, assign the "Type: Feature Request :heavy_plus_sign:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -111,7 +124,7 @@ configuration:
           - addLabel:
               label: "Type: Feature Request :heavy_plus_sign:"
 
-      - description: 'ITA21 - If the type is bug, add the "Type: Bug :bug:" label on the issue'
+      - description: 'ITA21 - If the type is bug, assign the "Type: Bug :bug:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -127,6 +140,23 @@ configuration:
         then:
           - addLabel:
               label: "Type: Bug :bug:"
+
+      - description: 'ITA22 - If the type is security bug, assign the "Type: Security Bug :lock:" label on the issue'
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: |
+                ### Issue Type?
+
+                Security Bug
+          - not:
+              hasLabel:
+                label: "Type: Security Bug :lock:"
+        then:
+          - addLabel:
+              label: "Type: Security Bug :lock:"
 
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -23,6 +23,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 5
         actions:
@@ -52,6 +54,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 3
         actions:
@@ -86,6 +90,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 5
         actions:
@@ -102,7 +108,7 @@ configuration:
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
 
-      - description: "ITA02TF.2 - Label issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
+      - description: "ITA02TF.2 - Label and comment issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
         frequencies:
           - weekday:
               day: Thursday
@@ -115,6 +121,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 3
         actions:
@@ -123,7 +131,7 @@ configuration:
                 - Azure/avm-core-team-technical-terraform
               replyTemplate: |
                 > [!CAUTION]
-                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days. **
+                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days.**
 
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
@@ -175,12 +183,11 @@ configuration:
           - assignTo:
               user: Azure/terraform-avm
 
-      - description: "ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days."
+      - description: "ITA04 - Label issues and PRs that have been marked as requiring author feedback but have not had any activity for 4 days."
         frequencies:
           - hourly:
               hour: 3
         filters:
-          - isIssue
           - isOpen
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
@@ -196,48 +203,4 @@ configuration:
           - addReply:
               reply: |
                 > [!IMPORTANT]
-                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
-
-      - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Needs: Module Owner :mega:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
-
-      - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Status: Long Term :hourglass_flowing_sand:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
+                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-Issues can be created and searched through for existing [issues here](https://github.com/Azure/terraform-azurerm-avm-res-network-applicationgateway/issues).
+Issues can be created and searched through for existing [issues here](../../issues).
 
 Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
 

--- a/avm
+++ b/avm
@@ -11,6 +11,8 @@ if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
     exit 1
 fi
 
+AVM_IMAGE=${AVM_IMAGE:-mcr.microsoft.com/azterraform}
+
 if [ -z "$1" ]; then
     echo "Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets."
     echo
@@ -26,7 +28,7 @@ fi
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"
+  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/avm.bat
+++ b/avm.bat
@@ -11,13 +11,21 @@ IF ERRORLEVEL 1 (
     exit /b
 )
 
+IF DEFINED AVM_IMAGE (SET "AVM_IMAGE=%AVM_IMAGE%") ELSE (SET "AVM_IMAGE=mcr.microsoft.com/azterraform")
+
 REM Check if a make target is provided
 IF "%~1"=="" (
     echo Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets.
     exit /b
 )
 
+IF DEFINED NO_PULL (
+    SET "PULL_ARG="
+) ELSE (
+    SET "PULL_ARG=--pull always"
+)
+
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run %PULL_ARG% --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER %AVM_IMAGE% make %1
 
 ENDLOCAL

--- a/examples/default/pre-requisites-main.tf
+++ b/examples/default/pre-requisites-main.tf
@@ -24,10 +24,10 @@ resource "azurerm_resource_group" "rg_vnet" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_vnet.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_vnet.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/front_end_ip_private_custom_name/pre-requisites-main.tf
+++ b/examples/front_end_ip_private_custom_name/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/front_end_ip_private_custom_name_privateonly/pre-requisites-main.tf
+++ b/examples/front_end_ip_private_custom_name_privateonly/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/kv_selfssl_waf_https_app_gateway/pre-requisites-main.tf
+++ b/examples/kv_selfssl_waf_https_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/kv_selfssl_waf_https_app_gateway_privateonly/pre-requisites-main.tf
+++ b/examples/kv_selfssl_waf_https_app_gateway_privateonly/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/rewrite_rule/pre-requisites-main.tf
+++ b/examples/rewrite_rule/pre-requisites-main.tf
@@ -11,10 +11,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/selfssl_waf_https_app_gateway/pre-requisites-main.tf
+++ b/examples/selfssl_waf_https_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_app_gateway_internal/pre-requisites-main.tf
+++ b/examples/simple_http_app_gateway_internal/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_host_multiple_sites_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_host_multiple_sites_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_host_single_site_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_host_single_site_app_gateway/pre-requisites-main.tf
@@ -24,10 +24,10 @@ resource "azurerm_resource_group" "rg_vnet" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_vnet.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_vnet.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_probe_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_probe_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_waf_http_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_waf_http_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/main.tf
+++ b/main.tf
@@ -76,8 +76,8 @@ resource "azurerm_application_gateway" "this" {
       }
     }
   }
-  # Private Frontend IP configuration 
-  # 139 Importing configuration from protal and setting the default values the frontend_ip_configuration block should be private and public 
+  # Private Frontend IP configuration
+  # 139 Importing configuration from protal and setting the default values the frontend_ip_configuration block should be private and public
   dynamic "frontend_ip_configuration" {
     for_each = var.frontend_ip_configuration_private.private_ip_address == null ? [] : [var.frontend_ip_configuration_private]
 
@@ -334,7 +334,7 @@ resource "azurerm_application_gateway" "this" {
     content {
       cipher_suites        = ssl_policy.value.cipher_suites
       disabled_protocols   = ssl_policy.value.disabled_protocols
-      min_protocol_version = ssl_policy.value.min_protocol_version
+      min_protocol_version = ssl_policy.value.policy_type == "Predefined" ? null : ssl_policy.value.min_protocol_version
       policy_name          = ssl_policy.value.policy_name
       policy_type          = ssl_policy.value.policy_type
     }
@@ -354,7 +354,7 @@ resource "azurerm_application_gateway" "this" {
         content {
           cipher_suites        = ssl_policy.value.cipher_suites
           disabled_protocols   = ssl_policy.value.disabled_protocols
-          min_protocol_version = ssl_policy.value.min_protocol_version
+          min_protocol_version = ssl_policy.value.policy_type == "Predefined" ? null : ssl_policy.value.min_protocol_version
           policy_name          = ssl_policy.value.policy_name
           policy_type          = ssl_policy.value.policy_type
         }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/variables.tf
+++ b/variables.tf
@@ -635,7 +635,6 @@ DESCRIPTION
     error_message = "policy_type must be one of: Predefined, Custom, or CustomV2."
   }
   validation {
-
     condition     = try(var.ssl_policy.min_protocol_version == null ? false : contains(["TLSv1_2", "TLSv1_3"], var.ssl_policy.min_protocol_version), true)
     error_message = "min_protocol_version must be TLSv1_2 or TLSv1_3 if specified."
   }
@@ -671,7 +670,6 @@ variable "ssl_profile" {
 DESCRIPTION
 
   validation {
-
     condition = try(alltrue([
       for _, profile in var.ssl_profile : try(profile.ssl_policy.policy_type == null ? false : contains(["Predefined", "Custom", "CustomV2"], profile.ssl_policy.policy_type), true)
     ]), true)


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

This pull request sets the `min_protocol_version` field inside _ssl_policy_ or _ssl_profile.ssl_policy_ to _null_, if the policy type is predefined.

Fixes #146 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
