### PR TITLE
Add possilbilty to have multiple public IPs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# AVM core team owns key files
-.github/policies/ @Azure/avm-core-team-technical-terraform
 .github/CODEOWNERS @Azure/avm-core-team-technical-terraform

--- a/.github/policies/eventResponder.yml
+++ b/.github/policies/eventResponder.yml
@@ -17,6 +17,13 @@ configuration:
         then:
           - addLabel:
               label: "Needs: Triage :mag:"
+          - addReply:
+              reply: |
+                > [!IMPORTANT]
+                > **The "Needs: Triage :mag:" label must be removed once the triage process is complete!**
+
+                > [!TIP]
+                > For additional guidance on how to triage this issue/PR, see the [Terraform Issue Triage](https://azure.github.io/Azure-Verified-Modules/help-support/issue-triage/terraform-issue-triage) documentation.
 
       - description: 'ITA09 - When #RR is used in an issue, add the "Needs: Author Feedback :ear:" label'
         if:
@@ -47,7 +54,7 @@ configuration:
               label: "Status: Won't Fix :broken_heart:"
           - closeIssue
 
-      - description: 'ITA11 - When a reply from anyone to an issue occurs, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
+      - description: 'ITA11 - When the author replies, remove the "Needs: Author Feedback :ear:" label and label with "Needs: Attention :wave:"'
         if:
           - or:
               - payloadType: Pull_Request_Review_Comment
@@ -57,9 +64,13 @@ configuration:
                 action: Closed
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
+          - isActivitySender:
+              issueAuthor: true
         then:
           - removeLabel:
               label: "Needs: Author Feedback :ear:"
+          - removeLabel:
+              label: "Status: No Recent Activity :zzz:"
           - addLabel:
               label: "Needs: Attention :wave:"
 
@@ -89,12 +100,14 @@ configuration:
                   label: "Type: New Module Proposal :bulb:"
               - hasLabel:
                   label: "Type: Question/Feedback :raising_hand:"
+              - hasLabel:
+                  label: "Type: Security Bug :lock:"
           - isAssignedToSomeone
         then:
           - removeLabel:
               label: "Needs: Triage :mag:"
 
-      - description: 'ITA20 - If the type is feature request, add the "Type: Feature Request :heavy_plus_sign:" label on the issue'
+      - description: 'ITA20 - If the type is feature request, assign the "Type: Feature Request :heavy_plus_sign:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -111,7 +124,7 @@ configuration:
           - addLabel:
               label: "Type: Feature Request :heavy_plus_sign:"
 
-      - description: 'ITA21 - If the type is bug, add the "Type: Bug :bug:" label on the issue'
+      - description: 'ITA21 - If the type is bug, assign the "Type: Bug :bug:" label on the issue'
         if:
           - payloadType: Issues
           - isAction:
@@ -127,6 +140,23 @@ configuration:
         then:
           - addLabel:
               label: "Type: Bug :bug:"
+
+      - description: 'ITA22 - If the type is security bug, assign the "Type: Security Bug :lock:" label on the issue'
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: |
+                ### Issue Type?
+
+                Security Bug
+          - not:
+              hasLabel:
+                label: "Type: Security Bug :lock:"
+        then:
+          - addLabel:
+              label: "Type: Security Bug :lock:"
 
       - description: 'ITA23 - Remove the "Status: In PR" label from an issue when it''s closed.'
         if:

--- a/.github/policies/scheduledSearches.yml
+++ b/.github/policies/scheduledSearches.yml
@@ -23,6 +23,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 5
         actions:
@@ -52,6 +54,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Needs: Triage :mag:"
+          - isNotLabeledWith:
+              label: "Status: Response Overdue :triangular_flag_on_post:"
           - noActivitySince:
               days: 3
         actions:
@@ -86,6 +90,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 5
         actions:
@@ -102,7 +108,7 @@ configuration:
           - addLabel:
               label: "Needs: Immediate Attention :bangbang:"
 
-      - description: "ITA02TF.2 - Label issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
+      - description: "ITA02TF.2 - Label and comment issues as Needs Immediate Attention and leave comment if after an additional 3 business days there's still no update to the issue."
         frequencies:
           - weekday:
               day: Thursday
@@ -115,6 +121,8 @@ configuration:
           - isOpen
           - hasLabel:
               label: "Status: Response Overdue :triangular_flag_on_post:"
+          - isNotLabeledWith:
+              label: "Needs: Immediate Attention :bangbang:"
           - noActivitySince:
               days: 3
         actions:
@@ -123,7 +131,7 @@ configuration:
                 - Azure/avm-core-team-technical-terraform
               replyTemplate: |
                 > [!CAUTION]
-                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days. **
+                > **This issue requires the AVM Core Team's (${mentionees}) immediate attention as  it hasn't been responded to within 6 business days.**
 
                 > [!TIP]
                 > - To avoid this rule being (re)triggered, the "Needs: Triage :mag:" and "Status: Response Overdue :triangular_flag_on_post:" labels must be removed when the issue is first responded to!
@@ -175,12 +183,11 @@ configuration:
           - assignTo:
               user: Azure/terraform-avm
 
-      - description: "ITA04 - Label issues that have been marked as requiring author feedback but have not had any activity for 4 days."
+      - description: "ITA04 - Label issues and PRs that have been marked as requiring author feedback but have not had any activity for 4 days."
         frequencies:
           - hourly:
               hour: 3
         filters:
-          - isIssue
           - isOpen
           - hasLabel:
               label: "Needs: Author Feedback :ear:"
@@ -196,48 +203,4 @@ configuration:
           - addReply:
               reply: |
                 > [!IMPORTANT]
-                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**.
-
-      - description: 'ITA05A - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Needs: Module Owner :mega:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
-
-      - description: 'ITA05B - Close issues that have been marked as requiring author feedback but have not had any activity for 3 days, unless it''s been marked with the "Status long term" label.'
-        frequencies:
-          - hourly:
-              hour: 3
-        filters:
-          - isIssue
-          - isOpen
-          - hasLabel:
-              label: "Needs: Author Feedback :ear:"
-          - hasLabel:
-              label: "Status: No Recent Activity :zzz:"
-          - isNotLabeledWith:
-              label: "Status: Long Term :hourglass_flowing_sand:"
-          - noActivitySince:
-              days: 3
-        actions:
-          - addReply:
-              reply: |
-                > [!WARNING]
-                > @${issueAuthor}, this issue will now be closed, as it has been marked as requiring author feedback but has not had any activity for **7 days**.
-          - closeIssue
+                > @${issueAuthor}, this issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -391,6 +391,24 @@ Type: `bool`
 
 Default: `null`
 
+### <a name="input_frontend_ip_configuration_additional_public_ips"></a> [frontend\_ip\_configuration\_additional\_public\_ips](#input\_frontend\_ip\_configuration\_additional\_public\_ips)
+
+Description: A map of additional pre-created public IPs to be assigned to FW configurations. Useful when you need more than one IPv4 and/or IPv6 public IP.
+
+ - `name` - (Optional) Override generated name for Public Frontend IP Configuration.
+ - `public_ip_address_id` - The Public IP Address to use for the Application Gateway.
+
+Type:
+
+```hcl
+map(object({
+    public_ip_address_id = string
+    name                 = optional(string)
+  }))
+```
+
+Default: `{}`
+
 ### <a name="input_frontend_ip_configuration_private"></a> [frontend\_ip\_configuration\_private](#input\_frontend\_ip\_configuration\_private)
 
 Description:  - `name` - (Optional) The name of the private  Frontend IP Configuration.
@@ -415,7 +433,7 @@ Default: `{}`
 
 ### <a name="input_frontend_ip_configuration_public_name"></a> [frontend\_ip\_configuration\_public\_name](#input\_frontend\_ip\_configuration\_public\_name)
 
-Description: (Optional) The name of the public Frontend IP Configuration.  If not supplied will be inferred from the resource name.
+Description: (Optional) The name of the public Frontend IP Configuration when `create_public_ip` is set to `true`.  If not supplied will be inferred from the resource name.
 
 Type: `string`
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-Issues can be created and searched through for existing [issues here](https://github.com/Azure/terraform-azurerm-avm-res-network-applicationgateway/issues).
+Issues can be created and searched through for existing [issues here](../../issues).
 
 Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
 

--- a/avm
+++ b/avm
@@ -6,16 +6,26 @@ usage () {
 
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
-if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
+
+if [ ! "$(command -v "$CONTAINER_RUNTIME")" ] && [ -z "$AVM_IN_CONTAINER" ]; then
     echo "Error: $CONTAINER_RUNTIME is not installed. Please install $CONTAINER_RUNTIME first."
     exit 1
 fi
+
+AVM_IMAGE=${AVM_IMAGE:-mcr.microsoft.com/azterraform}
 
 if [ -z "$1" ]; then
     echo "Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets."
     echo
     usage
     exit 1
+fi
+
+# Set pull option based on AVM_NO_CONTAINER_PULL
+if [ -z "$AVM_NO_CONTAINER_PULL" ]; then
+  PULL_OPTION="--pull always"
+else
+  PULL_OPTION=""
 fi
 
 # Check if AZURE_CONFIG_DIR is set, if not, set it to ~/.azure
@@ -26,7 +36,7 @@ fi
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make "$1"
+  $CONTAINER_RUNTIME run $PULL_OPTION --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/avm.bat
+++ b/avm.bat
@@ -11,13 +11,21 @@ IF ERRORLEVEL 1 (
     exit /b
 )
 
+IF DEFINED AVM_IMAGE (SET "AVM_IMAGE=%AVM_IMAGE%") ELSE (SET "AVM_IMAGE=mcr.microsoft.com/azterraform")
+
 REM Check if a make target is provided
 IF "%~1"=="" (
     echo Error: Please provide a make target. See https://github.com/Azure/tfmod-scaffold/blob/main/avmmakefile for available targets.
     exit /b
 )
 
+IF DEFINED NO_PULL (
+    SET "PULL_ARG="
+) ELSE (
+    SET "PULL_ARG=--pull always"
+)
+
 REM Run the make target with CONTAINER_RUNTIME
-%CONTAINER_RUNTIME% run --pull always --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER mcr.microsoft.com/azterraform make %1
+%CONTAINER_RUNTIME% run %PULL_ARG% --rm -v "%cd%":/src -w /src --user "1000:1000" -e GITHUB_TOKEN -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER %AVM_IMAGE% make %1
 
 ENDLOCAL

--- a/examples/default/pre-requisites-main.tf
+++ b/examples/default/pre-requisites-main.tf
@@ -24,10 +24,10 @@ resource "azurerm_resource_group" "rg_vnet" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_vnet.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_vnet.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/front_end_ip_private_custom_name/pre-requisites-main.tf
+++ b/examples/front_end_ip_private_custom_name/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/front_end_ip_private_custom_name_privateonly/pre-requisites-main.tf
+++ b/examples/front_end_ip_private_custom_name_privateonly/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/kv_selfssl_waf_https_app_gateway/pre-requisites-main.tf
+++ b/examples/kv_selfssl_waf_https_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/kv_selfssl_waf_https_app_gateway_privateonly/pre-requisites-main.tf
+++ b/examples/kv_selfssl_waf_https_app_gateway_privateonly/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/rewrite_rule/pre-requisites-main.tf
+++ b/examples/rewrite_rule/pre-requisites-main.tf
@@ -11,10 +11,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/selfssl_waf_https_app_gateway/pre-requisites-main.tf
+++ b/examples/selfssl_waf_https_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_app_gateway_internal/pre-requisites-main.tf
+++ b/examples/simple_http_app_gateway_internal/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_host_multiple_sites_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_host_multiple_sites_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_host_single_site_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_host_single_site_app_gateway/pre-requisites-main.tf
@@ -24,10 +24,10 @@ resource "azurerm_resource_group" "rg_vnet" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_vnet.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_vnet.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_http_probe_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_http_probe_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["100.64.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["100.64.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/examples/simple_waf_http_app_gateway/pre-requisites-main.tf
+++ b/examples/simple_waf_http_app_gateway/pre-requisites-main.tf
@@ -10,10 +10,10 @@ resource "azurerm_resource_group" "rg_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  address_space       = ["10.90.0.0/16"] # address space for VNET 
   location            = azurerm_resource_group.rg_group.location
   name                = module.naming.virtual_network.name_unique
   resource_group_name = azurerm_resource_group.rg_group.name
+  address_space       = ["10.90.0.0/16"] # address space for VNET 
 }
 
 resource "azurerm_subnet" "frontend" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,9 @@
 locals {
-  frontend_ip_configuration_name         = "${var.name}-feip"
-  frontend_ip_configuration_private_name = "${var.name}-fepvt-ip"
-  gateway_ip_configuration_name          = "${var.name}-gwipc"
-  identity_required                      = var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0
+  frontend_ip_configuration_additional_public_ip_names = { for pip, pip_params in var.frontend_ip_configuration_additional_public_ips : pip => pip_params.name == null ? "${pip}-fepip" : pip_params.name }
+  frontend_ip_configuration_name                       = "${var.name}-feip"
+  frontend_ip_configuration_private_name               = "${var.name}-fepvt-ip"
+  gateway_ip_configuration_name                        = "${var.name}-gwipc"
+  identity_required                                    = var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0
   managed_identities = {
     type = (
       var.managed_identities.system_assigned && length(var.managed_identities.user_assigned_resource_ids) > 0 ? "SystemAssigned, UserAssigned" :

--- a/main.tf
+++ b/main.tf
@@ -76,8 +76,17 @@ resource "azurerm_application_gateway" "this" {
       }
     }
   }
-  # Private Frontend IP configuration 
-  # 139 Importing configuration from protal and setting the default values the frontend_ip_configuration block should be private and public 
+  # Additional Public Frontend IP configurations
+  dynamic "frontend_ip_configuration" {
+    for_each = var.frontend_ip_configuration_additional_public_ips
+
+    content {
+      name                 = local.frontend_ip_configuration_additional_public_ip_names[frontend_ip_configuration.key]
+      public_ip_address_id = frontend_ip_configuration.value.public_ip_address_id
+    }
+  }
+  # Private Frontend IP configuration
+  # 139 Importing configuration from protal and setting the default values the frontend_ip_configuration block should be private and public
   dynamic "frontend_ip_configuration" {
     for_each = var.frontend_ip_configuration_private.private_ip_address == null ? [] : [var.frontend_ip_configuration_private]
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 1.9, < 2.0"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/variables.tf
+++ b/variables.tf
@@ -297,6 +297,20 @@ variable "fips_enabled" {
   description = "(Optional) Is FIPS enabled on the Application Gateway?"
 }
 
+variable "frontend_ip_configuration_additional_public_ips" {
+  type = map(object({
+    public_ip_address_id = string
+    name                 = optional(string)
+  }))
+  default     = {}
+  description = <<-DESCRIPTION
+A map of additional pre-created public IPs to be assigned to FW configurations. Useful when you need more than one IPv4 and/or IPv6 public IP.
+
+ - `name` - (Optional) Override generated name for Public Frontend IP Configuration.
+ - `public_ip_address_id` - The Public IP Address to use for the Application Gateway.
+DESCRIPTION
+}
+
 variable "frontend_ip_configuration_private" {
   type = object({
     name                            = optional(string)
@@ -319,7 +333,7 @@ DESCRIPTION
 variable "frontend_ip_configuration_public_name" {
   type        = string
   default     = null
-  description = "(Optional) The name of the public Frontend IP Configuration.  If not supplied will be inferred from the resource name."
+  description = "(Optional) The name of the public Frontend IP Configuration when `create_public_ip` is set to `true`.  If not supplied will be inferred from the resource name."
 }
 
 variable "global" {


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

At the moment there is possibility to create only one Public IP address. In general there can be multiple public IP addresses create, e.g. one IPv4 and one IPv6. 

The change is simple, it does not break the default creation of the public IP by the module, it only adds the possibility to provide multiple Public IP address IDs which is already created in the root module. 

Another useful use case can be that there is need to redeploy the Application Gateway without destroying used Public IP, e.g. when there are whitelists on 3rd party side, etc.


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
