### PR TITLE
Set SSL Certificates outputs as senstive (Fix issue 157)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -55,6 +55,7 @@ output "resource_id" {
 
 output "ssl_certificates" {
   description = "Information about SSL certificates used by the Application Gateway, including their names and other details."
+  sensitive   = true
   value       = azurerm_application_gateway.this.ssl_certificate
 }
 


### PR DESCRIPTION
## Description

To fix [issue 157](https://github.com/Azure/terraform-azurerm-avm-res-network-applicationgateway/issues/157), I propose declaring the output ssl_certificates as sensitive.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
