### PR TITLE
Make backend_address_pool_name and backend_http_settings_name optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -155,10 +155,10 @@ variable "request_routing_rules" {
     name                        = string
     rule_type                   = string
     http_listener_name          = string
-    backend_address_pool_name   = string
+    backend_address_pool_name   = optional(string)
     priority                    = number
     url_path_map_name           = optional(string)
-    backend_http_settings_name  = string
+    backend_http_settings_name  = optional(string)
     redirect_configuration_name = optional(string)
     rewrite_rule_set_name       = optional(string)
     # Define other attributes as needed


### PR DESCRIPTION
Changed backend_address_pool_name and backend_http_settings_name to optional.

## Description
Make backend_address_pool_name and backend_http_settings_name optional for request_routing_rules

Fixes #145


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
