### PR TITLE
CI-1108: Add Dependabot cooldown to mitigate supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
     directory: /tests
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Adds a 7-day cooldown period to Dependabot configuration
- This helps protect against supply-chain attacks by ensuring new package versions have time to be vetted by the community before adoption

## Jira

[CI-1108](https://mitarbeiterapp.atlassian.net/browse/CI-1108)

---
*This PR was created with [opencode](https://opencode.ai) using Claude Sonnet 4.5*